### PR TITLE
chore(deps): upgrade traefik and CRDs to v3.7.0-rc.2

### DIFF
--- a/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml
@@ -363,6 +363,9 @@ spec:
                                     - none
                                     - lax
                                     - strict
+                                    - None
+                                    - Lax
+                                    - Strict
                                     type: string
                                   secure:
                                     description: Secure defines whether the cookie

--- a/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml
@@ -526,6 +526,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -665,8 +668,10 @@ spec:
                         type: boolean
                     type: object
                   trustForwardHeader:
-                    description: 'TrustForwardHeader defines whether to trust (ie:
-                      forward) all X-Forwarded-* headers.'
+                    description: |-
+                      TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.
+
+                      Deprecated: Use forwardedHeaders.trustedIPs at the EntryPoint level instead, and set trustForwardHeader to true on this middleware.
                     type: boolean
                 type: object
               grpcWeb:

--- a/traefik-crds/crds-files/traefik/traefik.io_traefikservices.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_traefikservices.yaml
@@ -283,6 +283,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -530,6 +533,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -790,6 +796,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1156,6 +1165,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1305,6 +1317,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only
@@ -1558,6 +1573,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1628,6 +1646,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -4,7 +4,7 @@ description: A Traefik based Kubernetes ingress controller
 type: application
 version: 40.0.0-ea.3
 # renovate: image=traefik
-appVersion: v3.7.0-rc.1
+appVersion: v3.7.0-rc.2
 kubeVersion: ">=1.25.0-0"
 keywords:
   - traefik
@@ -23,7 +23,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
   traefik.io/proxy-min-version: v3.6.0
-  traefik.io/proxy-max-version: v3.7.0-rc.1
+  traefik.io/proxy-max-version: v3.7.0-rc.2
   traefik.io/hub-min-version: v3.19.3
   traefik.io/hub-max-version: v3.20.0-rc.1
   artifacthub.io/changes: |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 40.0.0-ea.3](https://img.shields.io/badge/Version-40.0.0--ea.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.0-rc.1](https://img.shields.io/badge/AppVersion-v3.7.0--rc.1-informational?style=flat-square)
+![Version: 40.0.0-ea.3](https://img.shields.io/badge/Version-40.0.0--ea.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.0-rc.2](https://img.shields.io/badge/AppVersion-v3.7.0--rc.2-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 

--- a/traefik/crds/traefik.io_ingressroutes.yaml
+++ b/traefik/crds/traefik.io_ingressroutes.yaml
@@ -363,6 +363,9 @@ spec:
                                     - none
                                     - lax
                                     - strict
+                                    - None
+                                    - Lax
+                                    - Strict
                                     type: string
                                   secure:
                                     description: Secure defines whether the cookie

--- a/traefik/crds/traefik.io_middlewares.yaml
+++ b/traefik/crds/traefik.io_middlewares.yaml
@@ -526,6 +526,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -665,8 +668,10 @@ spec:
                         type: boolean
                     type: object
                   trustForwardHeader:
-                    description: 'TrustForwardHeader defines whether to trust (ie:
-                      forward) all X-Forwarded-* headers.'
+                    description: |-
+                      TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.
+
+                      Deprecated: Use forwardedHeaders.trustedIPs at the EntryPoint level instead, and set trustForwardHeader to true on this middleware.
                     type: boolean
                 type: object
               grpcWeb:

--- a/traefik/crds/traefik.io_traefikservices.yaml
+++ b/traefik/crds/traefik.io_traefikservices.yaml
@@ -283,6 +283,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -530,6 +533,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -790,6 +796,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1156,6 +1165,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1305,6 +1317,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only
@@ -1558,6 +1573,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1628,6 +1646,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only


### PR DESCRIPTION
### What does this PR do?

Bumps Traefik to v3.7.0-rc.2. Regenerates the 3 CRDs that changed upstream
(`ingressroutes`, `middlewares`, `traefikservices`) and updates `appVersion`
and the `traefik.io/proxy-max-version` annotation.

Stacked on top of #1791.

### Motivation

Pick up the rc.2 bugfixes and the v2.11.43 / v3.6.14 back-merges, plus the
CRD schema changes:
- case-insensitive `sameSite` cookie values (`None` / `Lax` / `Strict`)
- deprecation notice on `ForwardAuth.trustForwardHeader`

No new CLI flag or chart option — `traefik --help` is byte-identical between
rc.1 and rc.2.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed