### PR TITLE
refactor(version): dedup max-version guard into shared helpers

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -8,11 +8,9 @@
 {{- $imageTag := (.Values.image.tag | default .Chart.AppVersion) -}}
 {{- $version := include "traefik.proxyVersion" $ -}}
 {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" -}}
-{{- if or (hasPrefix "experimental-" $imageTag) (and (eq (include "traefik.isStableVersion" $version) "false") (semverCompare (printf ">%s-0" $proxyMaxVersion) $version)) (and (eq (include "traefik.isStableVersion" $version) "true") (semverCompare (printf ">%s" $proxyMaxVersion) $version)) -}}
+{{- if or (hasPrefix "experimental-" $imageTag) (eq (include "traefik.isAboveMaxVersion" (dict "version" $version "max" $proxyMaxVersion)) "true") -}}
 {{- printf "\n" -}}
-⚠️ WARNING: You are using a non-standard image tag ({{ $imageTag }}). Non-standard versions can
-be unstable, may contain breaking changes, and are NOT recommended for production use.
-This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{ include "traefik.nonStandardVersionWarning" (dict "label" "image tag" "tag" $imageTag) }}
 {{- printf "\n" -}}
 {{- end -}}
 
@@ -21,11 +19,9 @@ This version is not officially supported by this chart. Use at your own risk. �
 {{- if .Values.hub.token -}}
 {{- $hubVersion := include "traefik.hubVersion" $ -}}
 {{- $hubMaxVersion := index .Chart.Annotations "traefik.io/hub-max-version" -}}
-{{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (or (and (eq (include "traefik.isStableVersion" $hubVersion) "false") (semverCompare (printf ">%s-0" $hubMaxVersion) $hubVersion)) (and (eq (include "traefik.isStableVersion" $hubVersion) "true") (semverCompare (printf ">%s" $hubMaxVersion) $hubVersion))) -}}
+{{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (eq (include "traefik.isAboveMaxVersion" (dict "version" $hubVersion "max" $hubMaxVersion)) "true") -}}
 {{- printf "\n" -}}
-⚠️ WARNING: You are using a non-standard Traefik Hub image tag ({{ $hubVersion }}). Non-standard versions can
-be unstable, may contain breaking changes, and are NOT recommended for production use.
-This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{ include "traefik.nonStandardVersionWarning" (dict "label" "Traefik Hub image tag" "tag" $hubVersion) }}
 {{- printf "\n" -}}
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -223,6 +223,36 @@ Non-standard versions include experimental, ea, rc, alpha, beta builds.
 {{- end -}}
 
 {{/*
+Returns "true" when version is above max but shares the same major (the "use at your own
+risk" warning case). Pre-releases compare against "max-0" to also flag pre-releases of a
+version above max. Expects a dict: version, max.
+*/}}
+{{- define "traefik.isAboveMaxVersion" -}}
+  {{- if eq (include "traefik.isStableVersion" .version) "true" -}}
+    {{- semverCompare (printf ">%s" .max) .version -}}
+  {{- else -}}
+    {{- semverCompare (printf ">%s-0" .max) .version -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when version's major is strictly above max's major (the hard-fail case).
+Expects a dict: version, max.
+*/}}
+{{- define "traefik.isMajorAboveMax" -}}
+  {{- semverCompare (printf ">=%d.0.0-0" (add1 (int (semver .max).Major))) .version -}}
+{{- end -}}
+
+{{/*
+Renders the non-standard version warning shown in NOTES.txt. Expects a dict: label, tag.
+*/}}
+{{- define "traefik.nonStandardVersionWarning" -}}
+⚠️ WARNING: You are using a non-standard {{ .label }} ({{ .tag }}). Non-standard versions can
+be unstable, may contain breaking changes, and are NOT recommended for production use.
+This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{- end -}}
+
+{{/*
 The version can comes many sources: appVersion, image.tag, override, marketplace.
 */}}
 {{- define "traefik.proxyVersion" -}}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -6,8 +6,8 @@
     {{- fail (printf "ERROR: This version of the Chart only supports Traefik Proxy %s+" $proxyMinVersion) -}}
   {{- end }}
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
-  {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $proxyMaxVersion).Major))) $version }}
-    {{- fail (printf "ERROR: This version of the Chart does not support Traefik Proxy %s, which is a major version above the supported %s." $version $proxyMaxVersion) -}}
+  {{- if eq (include "traefik.isMajorAboveMax" (dict "version" $version "max" $proxyMaxVersion)) "true" }}
+    {{- fail (printf "ERROR: This Chart does not support Traefik Proxy %s, which is a major version above the supported %s." $version $proxyMaxVersion) -}}
   {{- end }}
 {{- end }}
 
@@ -147,8 +147,8 @@
     {{ fail (printf "ERROR: this Chart supports *only* Traefik Hub >= %s." $hubMinVersion) }}
   {{- end }}
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
-  {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $hubMaxVersion).Major))) $hubVersion }}
-    {{ fail (printf "ERROR: this Chart does not support Traefik Hub %s, which is a major version above the supported %s." $hubVersion $hubMaxVersion) }}
+  {{- if eq (include "traefik.isMajorAboveMax" (dict "version" $hubVersion "max" $hubMaxVersion)) "true" }}
+    {{ fail (printf "ERROR: This Chart does not support Traefik Hub %s, which is a major version above the supported %s." $hubVersion $hubMaxVersion) }}
   {{- end }}
 
   {{- if and (not $.Values.tracing.otlp.enabled) .Values.hub.tracing.additionalTraceHeaders.enabled }}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -50,14 +50,14 @@ tests:
         tag: v99.0.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4."
   - it: should fail when trying to use this Chart with a Proxy major pre-release above max
     set:
       image:
         tag: v4.0.0-rc.1
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:
@@ -136,7 +136,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: this Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:


### PR DESCRIPTION
Suggested refactor on top of your #1883 work (traefik/traefik-helm-chart#1884). No behavior change — pure dedup + string unification. All 683 unit tests pass.

### What

The warn/fail version-comparison expressions and the warning text were duplicated across Proxy and Hub paths. This factors them into shared helpers:

- `traefik.isAboveMaxVersion` (dict `version`, `max`) — same-major above-max **warn** check (NOTES.txt)
- `traefik.isMajorAboveMax` (dict `version`, `max`) — higher-major **hard-fail** check (requirements.yaml)
- `traefik.nonStandardVersionWarning` (dict `label`, `tag`) — single warning text, `label`-parametrized (`image tag` / `Traefik Hub image tag`)

Also unifies the Proxy/Hub hard-fail error strings, which differed (`This version of the Chart...` vs `this Chart...`) — now both `This Chart does not support Traefik {Proxy,Hub} %s, which is a major version above the supported %s.` Test expectations updated to match.

### Why

Single source of truth for the warn threshold, the fail threshold, and the warning text — Proxy and Hub stay in sync by construction.

### Tests

- `notes_test.yaml` + `requirements-config_test.yaml` pass (`equalRaw` byte-exact NOTES asserts unchanged).
- Full suite: 683/683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)