### PR TITLE
refactor(helpers): collapse image-default helpers to one-liners

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -15,43 +15,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Image registry: when left unset, defaults to ghcr.io for Traefik Hub (where the
-traefik-hub image lives) and docker.io for Traefik Proxy. Any explicit value is respected.
+Image defaults. An explicit image value always wins; otherwise the chart picks the
+Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwise.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- if .Values.image.registry -}}
-{{- .Values.image.registry -}}
-{{- else if .Values.hub.token -}}
-ghcr.io
-{{- else -}}
-docker.io
-{{- end -}}
+{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token))) -}}
 {{- end -}}
 
-{{/*
-Image repository: when left unset, defaults to traefik/traefik-hub for Traefik Hub and
-traefik for Traefik Proxy. Any explicit value is respected.
-*/}}
 {{- define "traefik.imageRepository" -}}
-{{- if .Values.image.repository -}}
-{{- .Values.image.repository -}}
-{{- else if .Values.hub.token -}}
-traefik/traefik-hub
-{{- else -}}
-traefik
-{{- end -}}
+{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token))) -}}
 {{- end -}}
 
-{{/*
-Default image tag: the latest (max) supported Hub version when Traefik Hub is enabled,
-otherwise the chart's appVersion (the latest supported Traefik Proxy version).
-*/}}
 {{- define "traefik.defaultTag" -}}
-{{- if .Values.hub.token -}}
-{{- index .Chart.Annotations "traefik.io/hub-max-version" -}}
-{{- else -}}
-{{- .Chart.AppVersion -}}
-{{- end -}}
+{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (not (empty .Values.hub.token)) -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### What

Small follow-up refactor on top of your `feat/hub-default-max-version` branch.

The three image-default helpers — `traefik.imageRegistry`, `traefik.imageRepository`, `traefik.defaultTag` — all share one shape: *explicit value wins, otherwise Hub default when `hub.token` is set, Proxy default otherwise*. This expresses that with `default` + `ternary`, collapsing each helper to a single line under one shared comment (38 → 14 lines).

```gotemplate
{{- define "traefik.imageRegistry" -}}
{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token))) -}}
{{- end -}}
```

### Notes

- Behavior identical — `default` keeps "explicit wins" (empty string is falsy), `ternary` picks the Hub/Proxy branch.
- No call sites or tests changed; `make test` green (689/689).
- Trade-off: `ternary <true> <false> <cond>` is the sprig idiom but less literal than `if/else` 

🤖 Generated with [Claude Code](https://claude.com/claude-code)